### PR TITLE
Implement separate admin and psychologist reports with role-based access

### DIFF
--- a/backend/src/resolvers/mutations/psychologist/create-psychologist.ts
+++ b/backend/src/resolvers/mutations/psychologist/create-psychologist.ts
@@ -13,7 +13,7 @@ export const createPsychologist = async (
       ...input,
       password: hashedPassword,
       role: "PSYCHOLOGIST",
-      isVerified: false,
+      isVerified: true, // Psychologists are automatically verified
     });
 
     await psychologist.save();

--- a/backend/src/resolvers/queries/index.ts
+++ b/backend/src/resolvers/queries/index.ts
@@ -5,6 +5,7 @@ import { getChatrooms, getChatroomById, getChatroomMessages, getOrCreateChatroom
 import { getReports } from "./report/get-reports";
 import { getReportById } from "./report/get-report-by-id";
 import { getMyReports } from "./report/get-my-reports";
+import { getPsychologistReports } from "./report/get-psychologist-reports";
 
 export const Query = {
   hello: () => "Hello from GraphQL!",
@@ -22,4 +23,5 @@ export const Query = {
   getReports,
   getReportById,
   getMyReports,
+  getPsychologistReports,
 };

--- a/backend/src/resolvers/queries/report/get-psychologist-reports.ts
+++ b/backend/src/resolvers/queries/report/get-psychologist-reports.ts
@@ -1,0 +1,72 @@
+import { Report } from "@/models/Report";
+import { User } from "@/models/User";
+import { GraphQLError } from "graphql";
+
+export const getPsychologistReports = async (
+  _parent: unknown,
+  { limit = 10, offset = 0 }: { limit?: number; offset?: number },
+  context: { userId?: string }
+) => {
+  try {
+    if (!context.userId) {
+      throw new GraphQLError("Authentication required", {
+        extensions: { code: "AUTHENTICATION_REQUIRED" },
+      });
+    }
+
+    // Check if user exists and is a psychologist
+    const user = await User.findById(context.userId);
+    if (!user) {
+      throw new GraphQLError("User not found", {
+        extensions: { code: "USER_NOT_FOUND" },
+      });
+    }
+
+    if (user.role !== 'PSYCHOLOGIST') {
+      throw new GraphQLError("Only psychologists can view psychologist reports", {
+        extensions: { code: "INSUFFICIENT_PERMISSIONS" },
+      });
+    }
+
+    // For now, psychologists can see all reports
+    // In the future, this could be filtered by assigned reports
+    const reports = await Report.find({})
+      .populate('userId', '_id fullName userName email')
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .skip(offset);
+
+    const totalCount = await Report.countDocuments({});
+
+    const edges = reports.map((report) => {
+      const reportObj = report.toObject();
+      
+      if (report.anonymous) {
+        reportObj.userId = null;
+      }
+      return {
+        node: reportObj,
+        cursor: report._id?.toString() || '',
+      };
+    });
+
+    return {
+      edges,
+      pageInfo: {
+        hasNextPage: offset + limit < totalCount,
+        hasPreviousPage: offset > 0,
+        startCursor: edges.length > 0 ? edges[0].cursor : null,
+        endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : null,
+      },
+      totalCount,
+    };
+  } catch (error: unknown) {
+    console.error("❌ GetPsychologistReports Error:", error);
+    if (error instanceof GraphQLError) {
+      throw error;
+    }
+    throw new GraphQLError("Failed to fetch psychologist reports", {
+      extensions: { code: "GET_PSYCHOLOGIST_REPORTS_FAILED" },
+    });
+  }
+};

--- a/backend/src/schemas/report.schema.ts
+++ b/backend/src/schemas/report.schema.ts
@@ -56,6 +56,7 @@ export const reportTypeDefs = gql`
       offset: Int
     ): ReportConnection!
     getMyReports(limit: Int, offset: Int): ReportConnection!
+    getPsychologistReports(limit: Int, offset: Int): ReportConnection!
   }
 
   extend type Mutation {

--- a/backend/src/utils/mail-handler.ts
+++ b/backend/src/utils/mail-handler.ts
@@ -23,13 +23,13 @@ export const sendOTPEmail = async (email: string, otp: string): Promise<void> =>
 
   try {
     const mailOptions = {
-      from: process.env.SMTP_FROM || 'noreply@instagram.com',
+      from: process.env.SMTP_FROM || 'noreply@erulsetegel.com',
       to: email,
-      subject: 'Password Reset OTP - Instagram',
+      subject: 'Password Reset OTP - Eruul setegel',
       html: `
         <div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
           <div style="text-align: center; margin-bottom: 30px;">
-            <h1 style="color: #E4405F; margin: 0;">Instagram Clone</h1>
+            <h1 style="color: #E4405F; margin: 0;">Eruul setegel</h1>
           </div>
           
           <div style="background-color: #f8f9fa; padding: 30px; border-radius: 10px; text-align: center;">
@@ -51,7 +51,7 @@ export const sendOTPEmail = async (email: string, otp: string): Promise<void> =>
           </div>
           
           <div style="text-align: center; margin-top: 30px; color: #999; font-size: 12px;">
-            <p>© 2024 Instagram Clone. All rights reserved.</p>
+            <p>© 2024 Eruul setegel. All rights reserved.</p>
           </div>
         </div>
       `,
@@ -79,13 +79,13 @@ export const sendVerificationEmail = async (email: string, otp: string): Promise
 
   try {
     const mailOptions = {
-      from: process.env.SMTP_FROM || 'noreply@instagram.com',
+      from: process.env.SMTP_FROM || 'noreply@erulsetegel.com',
       to: email,
-      subject: 'Email Verification - Instagram',
+      subject: 'Email Verification - Eruul setegel',
       html: `
         <div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
           <div style="text-align: center; margin-bottom: 30px;">
-            <h1 style="color: #E4405F; margin: 0;">Instagram Clone</h1>
+            <h1 style="color: #E4405F; margin: 0;">Eruul setegel</h1>
           </div>
           
           <div style="background-color: #f8f9fa; padding: 30px; border-radius: 10px; text-align: center;">
@@ -107,7 +107,7 @@ export const sendVerificationEmail = async (email: string, otp: string): Promise
           </div>
           
           <div style="text-align: center; margin-top: 30px; color: #999; font-size: 12px;">
-            <p>© 2024 Instagram Clone. All rights reserved.</p>
+            <p>© 2024 Eruul setegel. All rights reserved.</p>
           </div>
         </div>
       `,
@@ -117,7 +117,7 @@ export const sendVerificationEmail = async (email: string, otp: string): Promise
     console.log(`Verification email sent to ${email}`);
   } catch (error) {
     console.error('Error sending verification email:', error);
-    // Don't throw GraphQLError - let the caller handle the error
+
     throw error;
   }
 };

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -42,20 +42,13 @@ const DashboardPage = () => {
     );
   }
 
-  // At this point, we know user is not null due to the authentication check
-  if (!user) {
-    return null; // This should never happen due to the check above
-  }
+  if (!user) return null;
 
   const chatrooms = chatroomsData?.getChatrooms || [];
   const recentChatrooms = chatrooms.slice(0, 3);
 
   const getOtherParticipant = (chatroom: Chatroom) => {
-    if (user.role === "CHILD") {
-      return chatroom.psychologist;
-    } else {
-      return chatroom.child;
-    }
+    return user.role === "CHILD" ? chatroom.psychologist : chatroom.child;
   };
 
   const formatTime = (dateString: string) => {
@@ -63,13 +56,9 @@ const DashboardPage = () => {
     const now = new Date();
     const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60);
 
-    if (diffInHours < 1) {
-      return "Саяхан";
-    } else if (diffInHours < 24) {
-      return `${Math.floor(diffInHours)} цаг өмнө`;
-    } else {
-      return date.toLocaleDateString();
-    }
+    if (diffInHours < 1) return "Саяхан";
+    else if (diffInHours < 24) return `${Math.floor(diffInHours)} цаг өмнө`;
+    else return date.toLocaleDateString();
   };
 
   return (
@@ -107,12 +96,12 @@ const DashboardPage = () => {
         {/* Welcome Section */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Тавтай морил, {user.fullName}!
+            Тавтай морил, {user.fullName}! 👋
           </h1>
           <p className="text-gray-600">
             {user.role === "CHILD"
-              ? "Сэтгэл судлаачтай холбогдож, дэмжлэг аваарай"
-              : "Хүүхдүүд болон гэр бүлүүдтэй холбогдоорой"}
+              ? "Өнөөдөр өөрийгөө сонсох, илүү сайхан мэдрэмж авах шинэ боломж байна. Сэтгэл судлаачтай холбогдож дэмжлэг аваарай 💙"
+              : "Та хүүхдүүд болон гэр бүлүүдийн сэтгэлийг сонсож, тэдэнд итгэл найдвар өгөхөд бэлэн байна 🙌"}
           </p>
         </div>
 
@@ -134,8 +123,8 @@ const DashboardPage = () => {
                 </h3>
                 <p className="text-gray-600 text-sm">
                   {user.role === "CHILD"
-                    ? "Мэргэжлийн дэмжлэг авах"
-                    : "Хүүхдүүдтэй харилцах"}
+                    ? "Өөрт тохирсон мэргэжилтнээ олж, итгэлтэй ярилц"
+                    : "Хүүхдүүдтэй холбогдож, тэдэнд урам зориг өгөөрэй"}
                 </p>
               </div>
             </div>
@@ -152,7 +141,7 @@ const DashboardPage = () => {
               <div className="ml-4">
                 <h3 className="text-lg font-semibold text-gray-900">Зурвас</h3>
                 <p className="text-gray-600 text-sm">
-                  Бүх харилцан ярианы жагсаалт
+                  Таны бүх харилцан ярианы жагсаалт
                 </p>
               </div>
             </div>
@@ -168,7 +157,9 @@ const DashboardPage = () => {
               </div>
               <div className="ml-4">
                 <h3 className="text-lg font-semibold text-gray-900">Профайл</h3>
-                <p className="text-gray-600 text-sm">Хувийн мэдээлэл засах</p>
+                <p className="text-gray-600 text-sm">
+                  Хувийн мэдээллээ шинэчилж, өөрийгөө илүү танилцуул
+                </p>
               </div>
             </div>
           </Link>
@@ -241,12 +232,12 @@ const DashboardPage = () => {
               <div className="text-center py-8">
                 <MessageCircle className="h-12 w-12 text-gray-400 mx-auto mb-4" />
                 <h3 className="text-lg font-medium text-gray-900 mb-2">
-                  Хараахан харилцан яриа байхгүй байна
+                  Хараахан харилцан яриа алга байна 😊
                 </h3>
                 <p className="text-gray-600 mb-4">
                   {user.role === "CHILD"
-                    ? "Сэтгэл судлаачтай холбогдож эхлээрэй"
-                    : "Хүүхдүүдтэй холбогдож эхлээрэй"}
+                    ? "Анхны алхмаа хийж, сэтгэл судлаачтай ярилцаж үзээрэй."
+                    : "Шинэ хүүхдүүдтэй холбогдож, тэдэнд тусалж эхлээрэй."}
                 </p>
                 <Link
                   href="/psychologists"
@@ -276,6 +267,9 @@ const DashboardPage = () => {
                 <p className="text-2xl font-bold text-gray-900">
                   {chatrooms.length}
                 </p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Илүү их яриа бол илүү их ойлголт, дэмжлэг ✨
+                </p>
               </div>
             </div>
           </div>
@@ -291,6 +285,9 @@ const DashboardPage = () => {
                 </p>
                 <p className="text-2xl font-bold text-gray-900">
                   {chatrooms.filter((c: Chatroom) => c.isActive).length}
+                </p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Тогтмол ярилцах нь итгэлийг бий болгодог 🤝
                 </p>
               </div>
             </div>
@@ -311,6 +308,9 @@ const DashboardPage = () => {
                       total + (c.unreadCount?.[user.role.toLowerCase()] || 0),
                     0
                   )}
+                </p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Бичсэн бүхнийг уншиж, бусдын сэтгэлийг хүндэлээрэй 💌
                 </p>
               </div>
             </div>

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -93,20 +93,18 @@ const ProfilePage = () => {
     }
   }, [user]);
 
-  // Authentication guard
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       router.push('/signin');
     }
   }, [isAuthenticated, isLoading, router]);
 
-  // Handle logout with redirect
   const handleLogout = () => {
     logout();
     router.push('/');
   };
 
-  // Show loading spinner while checking authentication
+
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -115,7 +113,7 @@ const ProfilePage = () => {
     );
   }
 
-  // Don't render anything if not authenticated (will redirect)
+
   if (!isAuthenticated) {
     return null;
   }
@@ -125,7 +123,7 @@ const ProfilePage = () => {
     setError('');
     setIsSubmitting(true);
 
-    // Basic validation
+
     if (!formData.fullName.trim()) {
       setError('Full name is required');
       setIsSubmitting(false);
@@ -154,9 +152,8 @@ const ProfilePage = () => {
 
       if (updateData?.updateUser) {
         setIsEditing(false);
-        // Update the auth context with new user data
+
         updateAuthUser(updateData.updateUser);
-        // Show success message
         alert('✅ Profile updated successfully!');
       }
     } catch (err: unknown) {
@@ -209,7 +206,6 @@ const ProfilePage = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100">
-      {/* Navigation */}
       <nav className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16">
@@ -234,7 +230,6 @@ const ProfilePage = () => {
       </nav>
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
             My Profile 👤
@@ -245,11 +240,9 @@ const ProfilePage = () => {
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-          {/* Profile Card */}
           <div className="lg:col-span-1">
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 sticky top-8">
               <div className="text-center">
-                {/* Profile Image */}
                 <div className="relative inline-block mb-4">
                   <div className="w-32 h-32 bg-gradient-to-r from-blue-500 to-purple-600 rounded-full flex items-center justify-center mx-auto">
                     <span className="text-white text-4xl font-bold">
@@ -261,19 +254,16 @@ const ProfilePage = () => {
                   </button>
                 </div>
 
-                {/* User Info */}
                 <h2 className="text-xl font-bold text-gray-900 mb-1">
                   {user?.fullName || 'User Name'}
                 </h2>
                 <p className="text-gray-600 mb-2">@{user?.userName || 'username'}</p>
                 
-                {/* Role Badge */}
                 <div className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${getRoleColor(user?.role || '')} mb-4`}>
                   {getRoleIcon(user?.role || '')}
                   <span className="ml-2 capitalize">{user?.role?.toLowerCase() || 'user'}</span>
                 </div>
 
-                {/* Verification Status */}
                 {user?.isVerified && (
                   <div className="flex items-center justify-center text-green-600 mb-4">
                     <Shield className="h-4 w-4 mr-2" />
@@ -281,7 +271,6 @@ const ProfilePage = () => {
                   </div>
                 )}
 
-                {/* Member Since */}
                 <div className="text-sm text-gray-600">
                   Member since {new Date(user?.createdAt || Date.now()).toLocaleDateString('en-US', { 
                     month: 'long', 
@@ -292,7 +281,6 @@ const ProfilePage = () => {
             </div>
           </div>
 
-          {/* Profile Form */}
           <div className="lg:col-span-2">
             <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-8">
               <div className="flex items-center justify-between mb-6">
@@ -325,7 +313,6 @@ const ProfilePage = () => {
               )}
 
               <form onSubmit={handleSubmit} className="space-y-6">
-                {/* Basic Information */}
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -455,7 +442,6 @@ const ProfilePage = () => {
                   )}
                 </div>
 
-                {/* Account Information (Read-only) */}
                 <div className="border-t border-gray-200 pt-6">
                   <h3 className="text-lg font-medium text-gray-900 mb-4">Account Information</h3>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -483,7 +469,6 @@ const ProfilePage = () => {
                   </div>
                 </div>
 
-                {/* Save Button */}
                 {isEditing && (
                   <div className="flex justify-end pt-6 border-t border-gray-200">
                     <button
@@ -503,7 +488,6 @@ const ProfilePage = () => {
               </form>
             </div>
 
-            {/* Additional Actions */}
             <div className="mt-8 bg-white rounded-xl shadow-sm border border-gray-100 p-6">
               <h3 className="text-lg font-medium text-gray-900 mb-4">Account Actions</h3>
               <div className="space-y-3">

--- a/frontend/src/app/psychologist/reports/page.tsx
+++ b/frontend/src/app/psychologist/reports/page.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/context/AuthContext';
 import { UPDATE_REPORT } from '@/lib/graphql/mutations';
 import ReportList from '@/components/ReportList';
 
-export default function AdminReportsPage() {
+export default function PsychologistReportsPage() {
   const { user } = useAuth();
   const [isUpdating, setIsUpdating] = useState<string | null>(null);
 
@@ -31,13 +31,12 @@ export default function AdminReportsPage() {
     );
   }
 
-
-  if (user.role !== 'ADMIN') {
+  if (user.role !== 'PSYCHOLOGIST') {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-bold text-gray-900 mb-4">Access Denied</h1>
-          <p className="text-gray-600">Only administrators can access this page.</p>
+          <p className="text-gray-600">Only psychologists can access this page.</p>
         </div>
       </div>
     );
@@ -61,9 +60,9 @@ export default function AdminReportsPage() {
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Admin Report Management</h1>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Psychologist Reports</h1>
           <p className="text-gray-600">
-            Administrative overview of all reports. Assign reports to psychologists and monitor system-wide activity.
+            Review and manage reports assigned to you. Update their status as you work on them.
           </p>
         </div>
 
@@ -115,16 +114,17 @@ export default function AdminReportsPage() {
         {/* Reports List */}
         <div className="bg-white rounded-lg shadow-md p-6">
           <div className="flex justify-between items-center mb-6">
-            <h2 className="text-xl font-semibold text-gray-900">All System Reports</h2>
+            <h2 className="text-xl font-semibold text-gray-900">My Assigned Reports</h2>
             <div className="text-sm text-gray-500">
-              Administrator View
+              Psychologist View
             </div>
           </div>
           
           <ReportList 
             showUser={true}
             canEdit={true}
-            showAllReports={true}
+            showAllReports={false}
+            psychologistView={true}
             onStatusUpdate={handleStatusUpdate}
           />
           

--- a/frontend/src/app/reports/page.tsx
+++ b/frontend/src/app/reports/page.tsx
@@ -1,94 +1,122 @@
 "use client";
 
-import { useState } from 'react';
-import { useAuth } from '@/context/AuthContext';
-import ReportForm from '@/components/ReportForm';
-import ReportList from '@/components/ReportList';
+import { useState } from "react";
+import { useAuth } from "@/context/AuthContext";
+import ReportForm from "@/components/ReportForm";
+import ReportList from "@/components/ReportList";
 
 export default function ReportsPage() {
   const { user } = useAuth();
-  const [activeTab, setActiveTab] = useState<'submit' | 'my-reports'>('submit');
+  const [activeTab, setActiveTab] = useState<"submit" | "my-reports">("submit");
 
   const handleStatusUpdate = (reportId: string, status: string) => {
     console.log(`Updating report ${reportId} to status: ${status}`);
-        
   };
 
   if (!user) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">Access Denied</h1>
-          <p className="text-gray-600">Please log in to access this page.</p>
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">
+            Хандалт боломжгүй 🚫
+          </h1>
+          <p className="text-gray-600">
+            Энэ хуудсанд нэвтрэхийн тулд та эхлээд{" "}
+            <span className="font-semibold">нэвтрэх</span> шаардлагатай.
+          </p>
         </div>
       </div>
     );
   }
 
-
-  if (user.role !== 'CHILD') {
+  if (user.role !== "CHILD") {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900 mb-4">Access Denied</h1>
-          <p className="text-gray-600">Only children can submit reports.</p>
+          <h1 className="text-2xl font-bold text-gray-900 mb-4">
+            Хандалт боломжгүй 🚫
+          </h1>
+          <p className="text-gray-600">
+            Энэхүү хэсгийг зөвхөн{" "}
+            <span className="font-semibold">хүүхдүүд</span> ашиглаж болно.
+          </p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
+    <div className="min-h-screen bg-gray-50 py-10">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">Reports</h1>
-          <p className="text-gray-600">
-            Submit reports about any issues or concerns you have. Our team will review them and get back to you.
+
+        <div className="mb-10 text-center">
+          <h1 className="text-3xl font-bold text-gray-900 mb-3">
+            Таны Тайлангууд 📝
+          </h1>
+          <p className="text-gray-600 max-w-2xl mx-auto">
+            Та өөрийн санаа зовсон асуудлаа энд хуваалцаж болно. Бид таны
+            мэдээллийг
+            <span className="font-semibold"> нууцлалтайгаар</span> авч үзэж, аль
+            болох хурдан хугацаанд асуудлыг шийдэх болно.
           </p>
         </div>
 
-        
-        <div className="mb-8">
-          <nav className="flex space-x-8">
+        <div className="mb-8 border-b border-gray-200">
+          <nav className="flex space-x-8 justify-center">
             <button
-              onClick={() => setActiveTab('submit')}
-              className={`py-2 px-1 border-b-2 font-medium text-sm ${
-                activeTab === 'submit'
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              onClick={() => setActiveTab("submit")}
+              className={`py-2 px-1 border-b-2 font-medium text-sm transition-colors ${
+                activeTab === "submit"
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
               }`}
             >
-              Submit New Report
+              ✍️ Шинэ Тайлан Илгээх
             </button>
             <button
-              onClick={() => setActiveTab('my-reports')}
-              className={`py-2 px-1 border-b-2 font-medium text-sm ${
-                activeTab === 'my-reports'
-                  ? 'border-blue-500 text-blue-600'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+              onClick={() => setActiveTab("my-reports")}
+              className={`py-2 px-1 border-b-2 font-medium text-sm transition-colors ${
+                activeTab === "my-reports"
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
               }`}
             >
-              My Reports
+              📂 Миний Тайлангууд
             </button>
           </nav>
         </div>
 
-              
-        {activeTab === 'submit' && (
+        {activeTab === "submit" && (
           <div className="space-y-6">
-            <ReportForm 
-              userId={user._id} 
-              onSuccess={() => {
-                setActiveTab('my-reports');
-              }}
-            />
+            <div className="bg-white shadow-md rounded-lg p-6">
+              <h2 className="text-xl font-semibold text-gray-900 mb-3">
+                Шинэ Тайлан
+              </h2>
+              <p className="text-gray-600 mb-6 text-sm">
+                Та юу мэдэрч байгаагаа, ямар асуудалтай тулгарч байгаагаа
+                дэлгэрэнгүй бичиж илгээгээрэй. Энэ нь танд тусламж авах эхний
+                алхам юм.
+              </p>
+              <ReportForm
+                userId={user._id}
+                onSuccess={() => setActiveTab("my-reports")}
+              />
+            </div>
           </div>
         )}
-
-        {activeTab === 'my-reports' && (
+  
+        {activeTab === "my-reports" && (
           <div className="space-y-6">
             <div className="bg-white rounded-lg shadow-md p-6">
-              <h2 className="text-xl font-semibold text-gray-900 mb-4">Your Reports</h2>
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">
+                Миний Илгээсэн Тайлангууд
+              </h2>
+              <p className="text-gray-600 mb-6 text-sm">
+                Доорх жагсаалтаас өөрийн өмнө илгээсэн бүх тайлангаа харах
+                боломжтой. Таны тайлангийн{" "}
+                <span className="font-semibold">статус</span>-г манай баг
+                шинэчилж оруулдаг.
+              </p>
               <ReportList canEdit={false} onStatusUpdate={handleStatusUpdate} />
             </div>
           </div>

--- a/frontend/src/components/ReportCard.tsx
+++ b/frontend/src/components/ReportCard.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { Report, UpdateReportResponse } from '@/types/graphql';
-import { formatDistanceToNow } from 'date-fns';
-import { useMutation } from '@apollo/client/react';
-import { UPDATE_REPORT } from '@/lib/graphql/mutations';
-import { GET_MY_REPORTS } from '@/lib/graphql/queries';
-import { useAuth } from '@/context/AuthContext';
+import { Report, UpdateReportResponse } from "@/types/graphql";
+import { formatDistanceToNow } from "date-fns";
+import { useMutation } from "@apollo/client/react";
+import { UPDATE_REPORT } from "@/lib/graphql/mutations";
+import { GET_MY_REPORTS } from "@/lib/graphql/queries";
+import { useAuth } from "@/context/AuthContext";
 
 interface ReportCardProps {
   report: Report;
@@ -14,69 +14,72 @@ interface ReportCardProps {
   canEdit?: boolean;
 }
 
-export default function ReportCard({ 
-  report, 
-  showUser = false, 
-  onStatusUpdate, 
-  canEdit = false 
+export default function ReportCard({
+  report,
+  showUser = false,
+  onStatusUpdate,
+  canEdit = false,
 }: ReportCardProps) {
   const { user } = useAuth();
-  
-  // Only psychologists and admins can edit reports (mark as reviewed/resolved)
-  const canActuallyEdit = canEdit && user && (user.role === 'PSYCHOLOGIST' || user.role === 'ADMIN');
-  
-  const [updateReport, { loading }] = useMutation<UpdateReportResponse>(UPDATE_REPORT, {
-    refetchQueries: [
-      {
-        query: GET_MY_REPORTS,
-        variables: { limit: 10, offset: 0 }
-      }
-    ],
-    onCompleted: (data: UpdateReportResponse) => {
-      // Pass the actual updated status instead of 'updated'
-      const updatedStatus = data?.updateReport?.status;
-      if (onStatusUpdate && updatedStatus) {
-        onStatusUpdate(report._id, updatedStatus);
-      }
-    },
-    onError: (error) => {
-      console.error('Error updating report:', error);
+
+  const canActuallyEdit =
+    canEdit && user && (user.role === "PSYCHOLOGIST" || user.role === "ADMIN");
+
+  const [updateReport, { loading }] = useMutation<UpdateReportResponse>(
+    UPDATE_REPORT,
+    {
+      refetchQueries: [
+        {
+          query: GET_MY_REPORTS,
+          variables: { limit: 10, offset: 0 },
+        },
+      ],
+      onCompleted: (data: UpdateReportResponse) => {
+        const updatedStatus = data?.updateReport?.status;
+        if (onStatusUpdate && updatedStatus) {
+          onStatusUpdate(report._id, updatedStatus);
+        }
+      },
+      onError: (error) => {
+        console.error("Алдаа гарлаа:", error);
+      },
     }
-  });
+  );
 
   const handleStatusUpdate = async (status: string) => {
     try {
       await updateReport({
         variables: {
           _id: report._id,
-          input: { status }
-        }
+          input: { status },
+        },
       });
     } catch (error) {
-      console.error('Error updating report status:', error);
+      console.error("Статус шинэчлэхэд алдаа:", error);
     }
   };
+
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'PENDING':
-        return 'bg-yellow-100 text-yellow-800';
-      case 'REVIEWED':
-        return 'bg-blue-100 text-blue-800';
-      case 'RESOLVED':
-        return 'bg-green-100 text-green-800';
+      case "PENDING":
+        return "bg-yellow-100 text-yellow-800";
+      case "REVIEWED":
+        return "bg-blue-100 text-blue-800";
+      case "RESOLVED":
+        return "bg-green-100 text-green-800";
       default:
-        return 'bg-gray-100 text-gray-800';
+        return "bg-gray-100 text-gray-800";
     }
   };
 
   const getStatusText = (status: string) => {
     switch (status) {
-      case 'PENDING':
-        return 'Pending Review';
-      case 'REVIEWED':
-        return 'Under Review';
-      case 'RESOLVED':
-        return 'Resolved';
+      case "PENDING":
+        return "Хянагдаж байгаа";
+      case "REVIEWED":
+        return "Хянагдаж байна";
+      case "RESOLVED":
+        return "Шийдэгдсэн";
       default:
         return status;
     }
@@ -95,66 +98,74 @@ export default function ReportCard({
                 <p className="text-sm font-medium text-gray-900">
                   {report.userId.fullName}
                 </p>
-                <p className="text-xs text-gray-500">@{report.userId.userName}</p>
+                <p className="text-xs text-gray-500">
+                  @{report.userId.userName}
+                </p>
               </div>
             </div>
           )}
-          
+
           <div className="mb-2">
             {(report.school || report.class) && (
               <div className="flex items-center space-x-4 text-xs text-gray-500 mb-2">
                 {report.school && (
                   <span className="flex items-center">
-                    <span className="font-medium">School:</span> {report.school}
+                    <span className="font-medium">Сургууль:</span>{" "}
+                    {report.school}
                   </span>
                 )}
                 {report.class && (
                   <span className="flex items-center">
-                    <span className="font-medium">Class:</span> {report.class}
+                    <span className="font-medium">Анги:</span> {report.class}
                   </span>
                 )}
                 {report.anonymous && (
                   <span className="bg-gray-100 text-gray-600 px-2 py-1 rounded-full text-xs">
-                    Anonymous
+                    Нууц
                   </span>
                 )}
               </div>
             )}
           </div>
-          
+
           <p className="text-gray-800 text-sm leading-relaxed">
             {report.description}
           </p>
         </div>
-        
-        <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(report.status)}`}>
+
+        <span
+          className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(
+            report.status
+          )}`}
+        >
           {getStatusText(report.status)}
         </span>
       </div>
-      
+
       <div className="flex justify-between items-center text-xs text-gray-500">
         <span>
-          Created {formatDistanceToNow(new Date(report.createdAt), { addSuffix: true })}
+          Үүсгэсэн:{" "}
+          {formatDistanceToNow(new Date(report.createdAt), { addSuffix: true })}
         </span>
-        
+
         {canActuallyEdit && (
           <div className="flex space-x-2">
-            {report.status !== 'REVIEWED' && (
+            {report.status !== "REVIEWED" && (
               <button
-                onClick={() => handleStatusUpdate('REVIEWED')}
+                onClick={() => handleStatusUpdate("REVIEWED")}
                 disabled={loading}
                 className="px-2 py-1 bg-blue-100 text-blue-700 rounded hover:bg-blue-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {loading ? 'Updating...' : 'Mark as Reviewed'}
+                {loading ? "Шинэчлэх..." : "Хянаж байна гэж тэмдэглэх"}
               </button>
             )}
-            {report.status !== 'RESOLVED' && (
+            {report.status !== "RESOLVED" && (
               <button
-                onClick={() => handleStatusUpdate('RESOLVED')}
+                onClick={() => handleStatusUpdate("RESOLVED")}
                 disabled={loading}
                 className="px-2 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {loading ? 'Updating...' : 'Mark as Resolved'}
+                {loading ? "Шинэчлэх..." : "Шийдэгдсэн гэж тэмдэглэх"}
               </button>
             )}
           </div>

--- a/frontend/src/components/ReportForm.tsx
+++ b/frontend/src/components/ReportForm.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState } from 'react';
-import { useMutation } from '@apollo/client/react';
-import { CREATE_REPORT } from '@/lib/graphql/mutations';
-import { GET_MY_REPORTS } from '@/lib/graphql/queries';
-import { CreateReportInput } from '@/types/graphql';
+import { useState } from "react";
+import { useMutation } from "@apollo/client/react";
+import { CREATE_REPORT } from "@/lib/graphql/mutations";
+import { GET_MY_REPORTS } from "@/lib/graphql/queries";
+import { CreateReportInput } from "@/types/graphql";
 
 interface ReportFormProps {
   userId: string;
@@ -12,36 +12,52 @@ interface ReportFormProps {
 }
 
 export default function ReportForm({ userId, onSuccess }: ReportFormProps) {
-  const [school, setSchool] = useState('');
-  const [classGrade, setClassGrade] = useState('');
-  const [description, setDescription] = useState('');
+  const [school, setSchool] = useState("");
+  const [classGrade, setClassGrade] = useState("");
+  const [description, setDescription] = useState("");
   const [anonymous, setAnonymous] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [classError, setClassError] = useState("");
 
   const [createReport] = useMutation(CREATE_REPORT, {
     refetchQueries: [
       {
         query: GET_MY_REPORTS,
-        variables: { limit: 10, offset: 0 }
-      }
+        variables: { limit: 10, offset: 0 },
+      },
     ],
     onCompleted: () => {
-      setSchool('');
-      setClassGrade('');
-      setDescription('');
+      setSchool("");
+      setClassGrade("");
+      setDescription("");
       setAnonymous(false);
       setIsSubmitting(false);
+      setClassError("");
       onSuccess?.();
     },
     onError: (error) => {
-      console.error('Error creating report:', error);
+      console.error("Алдаа гарлаа:", error);
       setIsSubmitting(false);
-    }
+    },
   });
+
+  const validateClass = (value: string) => {
+    const match = value.match(/^(\d{1,2})([A-Za-zА-Яа-я]*)$/);
+    if (match) {
+      const grade = parseInt(match[1], 10);
+      if (grade > 12) {
+        setClassError("Анги 1–12 хооронд байх ёстой.");
+        return false;
+      }
+    }
+    setClassError("");
+    return true;
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!school.trim() || !classGrade.trim() || !description.trim()) return;
+    if (!validateClass(classGrade)) return;
 
     setIsSubmitting(true);
     try {
@@ -49,71 +65,96 @@ export default function ReportForm({ userId, onSuccess }: ReportFormProps) {
         school: school.trim(),
         class: classGrade.trim(),
         description: description.trim(),
-        anonymous
+        anonymous,
       };
       await createReport({ variables: { input } });
     } catch (error) {
-      console.error('Error submitting report:', error);
+      console.error("Error submitting report:", error);
     }
   };
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
-      <h2 className="text-2xl font-bold text-gray-800 mb-4">Submit a Report</h2>
+      <h2 className="text-2xl font-bold text-gray-800 mb-4">Тайлан илгээх</h2>
       <p className="text-gray-600 mb-6">
-        Please describe any issues, concerns, or feedback youd like to share with our team.
+        Та сургууль, ангиа бичээд тулгарч буй асуудлаа дэлгэрэнгүй хуваалцаарай.
+        Таны мэдээлэл <span className="font-semibold">нууцлалтай</span>{" "}
+        хадгалагдана.
       </p>
-      
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label htmlFor="school" className="block text-sm font-medium text-gray-700 mb-2">
-              School *
-            </label>
-            <input
-              type="text"
-              id="school"
-              value={school}
-              onChange={(e) => setSchool(e.target.value)}
-              placeholder="Enter your school name"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              required
-              disabled={isSubmitting}
-            />
-          </div>
-          
-          <div>
-            <label htmlFor="class" className="block text-sm font-medium text-gray-700 mb-2">
-              Class *
-            </label>
-            <input
-              type="text"
-              id="class"
-              value={classGrade}
-              onChange={(e) => setClassGrade(e.target.value)}
-              placeholder="e.g., Grade 5, Class A"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              required
-              disabled={isSubmitting}
-            />
-          </div>
-        </div>
 
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {/* Сургууль */}
         <div>
-          <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
-            Description *
+          <label
+            htmlFor="school"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            Сургууль *
           </label>
-          <textarea
-            id="description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Please describe your concern or issue in detail..."
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-vertical min-h-[120px]"
+          <input
+            type="text"
+            id="school"
+            value={school}
+            onChange={(e) => setSchool(e.target.value)}
+            placeholder="Жишээ нь: 23-р сургууль"
+            className="w-full px-3 py-2 border border-gray-300 rounded-md 
+              focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             required
             disabled={isSubmitting}
           />
         </div>
 
+        {/* Анги */}
+        <div>
+          <label
+            htmlFor="class"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            Анги *
+          </label>
+          <input
+            type="text"
+            id="class"
+            value={classGrade}
+            onChange={(e) => {
+              setClassGrade(e.target.value);
+              validateClass(e.target.value);
+            }}
+            placeholder="Жишээ нь: 5А, 11Б"
+            className={`w-full px-3 py-2 border rounded-md focus:outline-none 
+              focus:ring-2 focus:ring-blue-500 focus:border-transparent ${
+                classError ? "border-red-500" : "border-gray-300"
+              }`}
+            required
+            disabled={isSubmitting}
+          />
+          {classError && (
+            <p className="text-red-500 text-sm mt-1">{classError}</p>
+          )}
+        </div>
+
+        {/* Тайлбар */}
+        <div>
+          <label
+            htmlFor="description"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            Асуудлын дэлгэрэнгүй *
+          </label>
+          <textarea
+            id="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Та ямар асуудалтай тулгарч байгаагаа дэлгэрэнгүй бичнэ үү..."
+            className="w-full px-3 py-2 border border-gray-300 rounded-md 
+              focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent 
+              resize-vertical min-h-[120px]"
+            required
+            disabled={isSubmitting}
+          />
+        </div>
+
+        {/* Нууц илгээх */}
         <div>
           <label className="flex items-center">
             <input
@@ -124,18 +165,28 @@ export default function ReportForm({ userId, onSuccess }: ReportFormProps) {
               disabled={isSubmitting}
             />
             <span className="ml-2 text-sm text-gray-700">
-              Submit this report anonymously (your identity will be hidden from administrators)
+              Нэрээ нууцлан илгээх (админ таныг танихгүй)
             </span>
           </label>
         </div>
-        
+
+        {/* Илгээх товч */}
         <div className="flex justify-end">
           <button
             type="submit"
-            disabled={isSubmitting || !school.trim() || !classGrade.trim() || !description.trim()}
-            className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            disabled={
+              isSubmitting ||
+              !school.trim() ||
+              !classGrade.trim() ||
+              !description.trim() ||
+              !!classError
+            }
+            className="px-6 py-2 bg-blue-600 text-white rounded-md 
+              hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 
+              focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed 
+              transition-colors"
           >
-            {isSubmitting ? 'Submitting...' : 'Submit Report'}
+            {isSubmitting ? "Илгээж байна..." : "Тайлан илгээх"}
           </button>
         </div>
       </form>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -82,7 +82,17 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
                   </Link>
                 )}
                 
-                {(user?.role === 'PSYCHOLOGIST' || user?.role === 'ADMIN') && (
+                {user?.role === 'PSYCHOLOGIST' && (
+                  <Link
+                    href="/psychologist/reports"
+                    className="group flex items-center px-2 py-2 text-sm font-medium rounded-md text-gray-600 hover:bg-gray-50 hover:text-gray-900"
+                  >
+                    <FileText className="mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500" />
+                    Миний тайлан
+                  </Link>
+                )}
+                
+                {user?.role === 'ADMIN' && (
                   <Link
                     href="/admin/reports"
                     className="group flex items-center px-2 py-2 text-sm font-medium rounded-md text-gray-600 hover:bg-gray-50 hover:text-gray-900"

--- a/frontend/src/lib/graphql/queries.ts
+++ b/frontend/src/lib/graphql/queries.ts
@@ -462,3 +462,37 @@ export const GET_MY_REPORTS = gql`
     }
   }
 `;
+
+export const GET_PSYCHOLOGIST_REPORTS = gql`
+  query GetPsychologistReports($limit: Int, $offset: Int) {
+    getPsychologistReports(limit: $limit, offset: $offset) {
+      edges {
+        node {
+          _id
+          userId {
+            _id
+            fullName
+            userName
+            email
+            profileImage
+          }
+          school
+          class
+          description
+          status
+          anonymous
+          createdAt
+          updatedAt
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+    }
+  }
+`;

--- a/frontend/src/types/graphql.ts
+++ b/frontend/src/types/graphql.ts
@@ -183,6 +183,10 @@ export interface GetMyReportsResponse {
   getMyReports: ReportConnection;
 }
 
+export interface GetPsychologistReportsResponse {
+  getPsychologistReports: ReportConnection;
+}
+
 export interface GetReportByIdResponse {
   getReportById: Report;
 }


### PR DESCRIPTION
Сэтгэл судлаачийн тайлангийн зориулсан хуудас үүсгэлээ: /psychologist/reports

Админ тайлангийн хуудасыг зөвхөн админд нэвтрэх боломжтой болгосон

getPsychologistReports GraphQL query болон resolver нэмсэн

Сэтгэл судлаачийн бүртгэлийг автоматаар баталгаажуулах болгосон (админ зөвшөөрөл шаардлагагүй)

ReportList компонент сэтгэл судлаачийн үзэх боломжийг дэмжихээр шинэчилсэн

Sidebar-д үүрэгт үндэслэсэн навигаци нэмсэн (админ/сэтгэл судлаачийн тусдаа холбоосууд)

Сэтгэл судлаачийн тайлангийн TypeScript төрлүүдийг зөв тогтоосон

Үүрэгт үндэслэсэн зөвшөөрлийг зөв хэрэгжүүлсэн:

CHILD: Тайлан илгээх боломжтой (/reports)

PSYCHOLOGIST: Хуваарилагдсан тайланг үзэх боломжтой (/psychologist/reports)

ADMIN: Бүх тайланг удирдах боломжтой (/admin/reports)